### PR TITLE
Fix infinite installation loop and tidy up folder structure

### DIFF
--- a/LSP-PowerShellEditorServices.sublime-settings
+++ b/LSP-PowerShellEditorServices.sublime-settings
@@ -3,7 +3,7 @@
 	// plugin decide.
 	// For Windows this is "powershell.exe", for macOS/Linux it's "pwsh".
 	"powershell_exe": "",
-	"version": "2.4.7",
+	"version": "3.4.2",
 	"selector": "source.powershell",
 	"schemes": ["file", "buffer"],
 	"initializationOptions": {},

--- a/plugin.py
+++ b/plugin.py
@@ -77,7 +77,7 @@ class PowerShellEditorServices(AbstractPlugin):
 
     @classmethod
     def start_script(cls) -> str:
-        return os.path.join(cls.basedir(), "Start-EditorServices.ps1")
+        return os.path.join(cls.basedir(), "PowerShellEditorServices", "Start-EditorServices.ps1")
 
     @classmethod
     def host_version(cls) -> str:
@@ -97,7 +97,13 @@ class PowerShellEditorServices(AbstractPlugin):
 
     @classmethod
     def dll_path(cls) -> str:
-        return os.path.join(cls.basedir(), cls.name(), "bin", "Common", "Microsoft.PowerShell.EditorServices.dll")
+        return os.path.join(
+            cls.basedir(),
+            "PowerShellEditorServices",
+            "bin",
+            "Common",
+            "Microsoft.PowerShell.EditorServices.dll"
+        )
 
     @classmethod
     def version_str(cls) -> str:
@@ -145,8 +151,7 @@ class PowerShellEditorServices(AbstractPlugin):
             zipfile = os.path.join(cls.storage_path(), "{}.zip".format(cls.name()))
             urlretrieve(URL.format(cls.version_str()), zipfile)
             with ZipFile(zipfile, "r") as f:
-                f.extractall(cls.storage_path())
-            os.rename(os.path.join(cls.storage_path(), cls.name()), cls.basedir())
+                f.extractall(cls.basedir())
             os.unlink(zipfile)
         except Exception:
             shutil.rmtree(cls.basedir(), ignore_errors=True)


### PR DESCRIPTION
This commit...

1. installs the language server and all its dependencies into _Package Storage/LSP-PowerShellEditorServices_ directory
2. fixes an issue with `dll_path()` which caused the language-server to be re-installed each time it is instantiated.
3. Both `start_script()` and `dll_path()` now use fixed "PowerShellEditorServices" instead of `cls.name()` because it is a fixed folder name, which isn't related with the display name of the service.
4. updates the server to latest release