### PR TITLE
Tweak startup arguments

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -32,6 +32,8 @@ class PowerShellEditorServices(AbstractPlugin):
             cls.powershell_exe(),
             "-ExecutionPolicy",
             "Bypass",
+            "-NoLogo",
+            "-NoProfile",
             "-File",
             cls.start_script(),
             "-BundledModulesPath",
@@ -53,6 +55,8 @@ class PowerShellEditorServices(AbstractPlugin):
     def get_unix_command(cls) -> List[str]:
         return [
             cls.powershell_exe(),
+            "-NoLogo",
+            "-NoProfile",
             cls.start_script(),
             "-BundledModulesPath",
             cls.bundled_modules_path(),

--- a/plugin.py
+++ b/plugin.py
@@ -30,8 +30,6 @@ class PowerShellEditorServices(AbstractPlugin):
     def get_windows_command(cls) -> List[str]:
         return [
             cls.powershell_exe(),
-            "-ExecutionPolicy",
-            "Bypass",
             "-NoLogo",
             "-NoProfile",
             "-File",


### PR DESCRIPTION
This PR...

1. suppresses logo and profile by adding `-NoLogo` and `-NoProfile` arguments
2. disables signature check bypassing as all downloaded binaries and scripts are now properly signed.